### PR TITLE
Remove unnecessary single-line comments 0021

### DIFF
--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -14,9 +14,5 @@ describe('AppController', () => {
     appController = app.get<AppController>(AppController);
   });
 
-  describe('root', () => {
-//    it('should return "Hello World!"', () => {
-//      expect(appController.getHello()).toBe('Hello World!');
-//    });
-  });
+  describe('root', () => {});
 });

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,8 +1,7 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller } from '@nestjs/common';
 import { AppService } from './app.service';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
-
 }

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class AppService {
-}
+export class AppService {}

--- a/backend/src/home/home.controller.ts
+++ b/backend/src/home/home.controller.ts
@@ -49,7 +49,6 @@ export class HomeController {
   @Post()
   createHome(@Body() newHome: CreateHomeDto, @User() user) {
     return user;
-    // return this.homeService.createHome(newHome);
   }
 
   @Put(':id')
@@ -65,7 +64,3 @@ export class HomeController {
     return this.homeService.deleteHomeById(id);
   }
 }
-
-// http://localhost:3000/home/Toronto/500000/1500000
-
-// http://localhost:3000/home?city=Toronto&minPrice=500000&maxPrice=1500000


### PR DESCRIPTION
Removes single-line comments that are not needed.

 - Closes #21 

Removes lines from:
 - `home.controller.ts`
 - `home.service.ts`
 - `home.controller.spec.ts`

In addition, the `Get` import in `home.controller.ts` is removed because it is not used.

When the commented lines are removed from `home.controller.spec.ts`, the arrow function becomes empty. A new issue is necessitated for an issue to write a test for the expected behavior for calling the root.

The code was tested in local with Postman for root (`'/'`) and home (`/home`).
