### PR TITLE
Make it so only the realtor who created home can update or delete 0028

### DIFF
--- a/backend/src/home/home.controller.ts
+++ b/backend/src/home/home.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
   Param,
   ParseIntPipe,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { HomeService } from './home.service';
 import { CreateHomeDto, HomeResponseDTO, UpdateHomeDto } from './dto/home.dto';
@@ -52,15 +53,31 @@ export class HomeController {
   }
 
   @Put(':id')
-  updateHome(
+  async updateHome(
     @Param('id', ParseIntPipe) id: number,
     @Body() body: UpdateHomeDto,
+    @User() user: UserInfo,
   ) {
+    const realtor = await this.homeService.getRealtorByHomeId(id);
+
+    if (realtor.id !== user.id) {
+      throw new UnauthorizedException();
+    }
+
     return this.homeService.updateHomeById(id, body);
   }
 
   @Delete(':id')
-  deleteHome(@Param('id', ParseIntPipe) id: number) {
+  async deleteHome(
+    @Param('id', ParseIntPipe) id: number,
+    @User() user: UserInfo,
+  ) {
+    const realtor = await this.homeService.getRealtorByHomeId(id);
+
+    if (realtor.id !== user.id) {
+      throw new UnauthorizedException();
+    }
+
     return this.homeService.deleteHomeById(id);
   }
 }

--- a/backend/src/home/home.service.ts
+++ b/backend/src/home/home.service.ts
@@ -174,4 +174,28 @@ export class HomeService {
 
     return;
   }
+
+  async getRealtorByHomeId(id: number) {
+    const home = await this.prismaService.home.findUnique({
+      where: {
+        id,
+      },
+      select: {
+        realtor: {
+          select: {
+            name: true,
+            id: true,
+            email: true,
+            phone: true,
+          },
+        },
+      },
+    });
+
+    if (!home) {
+      throw new NotFoundException();
+    }
+
+    return home.realtor;
+  }
 }


### PR DESCRIPTION
This PR
 - closes #28 

As according to the issue,

> Make it so that when the updateHome or deleteHome services is called, if the user logged in is not the same as the realtor user who created the home listing, the update or delete is not allowed and an unauthorized exception is thrown.

This is done by importing the `UnauthorizedException` package into `home.controller.ts`.

A function is created in `home.service.ts` to get the realtor id which created the home, so that it can be compared with the logged in user. If it is not the same, instead of the update or delete service being called, an Unauthorized Exception is thrown.